### PR TITLE
fix minio upload unknown file size

### DIFF
--- a/pkg/minio/minio.go
+++ b/pkg/minio/minio.go
@@ -38,11 +38,13 @@ func UploadFileToMinio(client *minio.Client, bucketName string, objectName strin
 		log.Println(err)
 	}
 
+	size := int64(len(f))
+
 	conttype = http.DetectContentType(f[:511])
 	log.Println(conttype)
 	reader = bytes.NewReader(f)
 
-	uploadInfo, err := client.PutObject(context.Background(), bucketName, objectName, reader, -1, minio.PutObjectOptions{ContentType: conttype})
+	uploadInfo, err := client.PutObject(context.Background(), bucketName, objectName, reader, size, minio.PutObjectOptions{ContentType: conttype})
 	if err != nil {
 		log.Fatalln(err)
 		return uploadInfo, err


### PR DESCRIPTION
 the UploadFileToMinio function use -1 as size param which it mean the file size is unknown
this cause minio allocate huge memory   even for small file  which cause performance issue
it allocate around 600 mb of memory each upload and it  take time for the garbage collector to free up the memory